### PR TITLE
palobby changes to chat internals (still testing)

### DIFF
--- a/pachat/ui/mods/pachat/room_context_menu.html
+++ b/pachat/ui/mods/pachat/room_context_menu.html
@@ -1,0 +1,67 @@
+<div id="roomContextMenu" class="dropdown clearfix">
+  
+    <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu" >
+
+<!-- ko with: model.selectedRoom -->
+<!-- ko with: model.selectedRoomUser -->
+
+<!-- ko if: friend() && online() -->
+        <li><a data-bind="click: model.roomContextMenuClick.bind( $data, $parent, 'startChat' )" tabindex="-1" href="#"><span class="menu-action">
+            <loc data-i18n="uberbar:chat.message" desc="">Chat</loc>
+        </span></a></li>
+<!-- /ko -->
+
+<!-- ko if: ! friend() && ! blocked() -->
+        <li><a data-bind="click: model.roomContextMenuClick.bind( $data, $parent, 'sendFriendRequest' )" tabindex="-1" href="#"><span class="menu-action">
+            <loc data-i18n="uberbar:send_friend_request.message" desc="">Send Friend Request</loc>
+        </span></a></li>
+<!-- /ko -->
+
+<!-- ko if: ! friend() && ! blocked() -->
+        <li><a data-bind="click: model.roomContextMenuClick.bind( $data, $parent, 'sendChatInvite' )" tabindex="-1" href="#"><span class="menu-action">
+            <loc data-i18n="uberbar:invite_to_chat.message" desc="">Invite to Chat</loc>
+        </span></a></li>
+<!-- /ko -->
+
+<!-- ko if: friend -->
+        <li><a data-bind="click: model.roomContextMenuClick.bind( $data, $parent, 'sendUnfriend' )" tabindex="-1" href="#"><span class="menu-action">
+            <loc data-i18n="uberbar:unfriend.message" desc="">Unfriend</loc>
+        </span></a></li>
+<!-- /ko -->
+
+<!-- ko ifnot: blocked -->
+        <li><a data-bind="click: model.roomContextMenuClick.bind( $data, $parent, 'block' )" tabindex="-1" href="#"><span class="menu-action">
+            <loc data-i18n="uberbar:block.message" desc="">Block</loc>
+        </span></a></li>
+<!-- /ko -->
+
+<!-- ko if: blocked -->
+        <li><a data-bind="click: model.roomContextMenuClick.bind( $data, $parent, 'unblock' )" tabindex="-1" href="#"><span class="menu-action">
+            <loc data-i18n="uberbar:unblock.message" desc="">Unblock</loc>
+        </span></a></li>
+<!-- /ko -->
+        
+<!-- ko if: model.selectedRoom() && model.selectedRoom().selfIsAdmin() && ! isMuted()-->
+        <li><a data-bind="click: model.roomContextMenuClick.bind( $data, $parent, 'mute' )" tabindex="-1" href="#"><span class="menu-action">
+            Mute
+        </span></a></li>
+        <!-- /ko -->
+
+<!-- ko if: model.selectedRoom() && model.selectedRoom().selfIsAdmin() && isMuted()-->
+        <li><a data-bind="click: model.roomContextMenuClick.bind( $data, $parent, 'unmute' )"  tabindex="-1" href="#"><span class="menu-action">
+            Unmute
+        </span></a></li>
+        <!-- /ko -->
+
+<!-- ko if: model.selectedRoom() && model.selectedRoom().selfIsAdmin() -->
+        <li><a data-bind="click: model.roomContextMenuClick.bind( $data, $parent, 'kick' )" tabindex="-1" href="#"><span class="menu-action">
+            Kick
+        </span></a></li>
+<!-- /ko -->
+
+<!-- /ko -->
+<!-- /ko -->
+
+    </ul>
+
+</div>

--- a/pachat/ui/mods/pachat/rooms.html
+++ b/pachat/ui/mods/pachat/rooms.html
@@ -1,0 +1,78 @@
+<!-- ko foreach: chatRooms -->
+                <div class="div-win chat-room">
+                    <div class="div-chat-room-window" data-bind="resizable: {minWidth: 300, handles : 'w, e', resize: function(event,ui) {$('.div-chat-room-window').css('left', 0);}, stop: function( event, ui ) { scrollDown(); } }">
+                        <div data-bind="css: { 'div-chat-header': !dirtyMention(), 'dirty': dirty() && !dirtyMention(), 'dirtyMention': dirtyMention() }">
+                            <div class="div-chat-room-title" data-bind="click: toggleMinimized">
+								<!-- ko ifnot: minimized -->
+								<div class="div-chat-room-name ellipsesoverflow" data-bind="text: roomName()+'('+usersCount()+') - chat provided by PA Stats. Try /help'"></div>
+								<!-- /ko -->
+								<!-- ko if: minimized -->
+								<div class="chat_message_preview">
+									<span class="div-chat-room-name" data-bind="text: roomName"></span> - 
+									<!-- ko if: lastMessage() -->
+									<span class="chat_message_time" data-bind="text: model.formatTime( new Date( lastMessage().time ), true )"></span>
+                                    <span data-bind="text: lastMessage().roomUser && lastMessage().roomUser.roomDisplayName(), css: { 'chat-room-user-name': lastMessage().roomUser && !lastMessage().roomUser.isModerator() && !lastMessage().roomUser.isAdmin(),
+															'chat-room-moderator-name': lastMessage().roomUser && lastMessage().roomUser.isModerator() && !lastMessage().roomUser.isAdmin(),
+															'chat-room-admin-name': lastMessage().roomUser && lastMessage().roomUser.isAdmin(),
+															'chat-room-self-name': lastMessage().roomUser && lastMessage().roomUser.uberId() === model.uberId()}"></span>:
+                                    <span class="chat-msg selectable-text" data-bind="text: lastMessage().content"></span>
+									<!-- /ko -->
+                                </div>
+								<!-- /ko -->
+                            </div>
+                            <div class="div-chat-win-controls">
+                        			  <div class="btn_win btn_win_min btn-chat-win-control" data-bind="click: toggleMinimized"></div>
+                                <div class="btn_win btn_win_close btn-chat-win-control" data-bind="click: close"></div>
+                            </div>
+                        </div>
+                        <!-- ko ifnot: minimized -->
+                        <div class="div-chat-room-cont">
+                            <div class="div-chat-room-body" data-bind="attr: {id: 'chat-'+roomName()}">
+<!-- ko foreach: sortedMessages -->
+  <!-- ko if: !roomUser || !roomUser.blocked() || roomUser.isAdmin() || roomUser.isModerator() -->
+	                                <div class="chat_message" data-bind="css: {'markedline': mentionsMe}">
+										<span class="chat_message_time" data-bind="text: model.formatTime( new Date(time), true ), click: model.toggle24HourTime"></span>
+	                                    <span data-bind="text: roomUser && roomUser.roomDisplayName(), event: { contextmenu: roomUser && model.showRoomContextMenu.bind( $data.roomUser, $parent, event) },
+										css: {'chat-room-user-name': !roomUser || ( !roomUser.isModerator() && !roomUser.isAdmin() ),
+																'chat-room-moderator-name': roomUser && roomUser.isModerator() && !roomUser.isAdmin(),
+																'chat-room-admin-name': roomUser && roomUser.isAdmin(),
+																'chat-room-muted-name': roomUser && roomUser.isMuted(),
+																'chat-room-self-name': roomUser && roomUser.uberId() == model.uberId() }"></span>:
+<!-- ko foreach: parts -->
+<!-- ko if: link  -->
+                                    <a class="chat-msg" data-bind="attr: { href: text, target : '_blank' }, text: text"></a>
+<!-- /ko -->
+<!-- ko ifnot: link  -->
+                                    <span class="chat-msg selectable-text" data-bind="text: text"></span>
+<!-- /ko -->
+<!-- /ko -->
+	                                </div>
+  <!-- /ko -->
+<!-- /ko -->
+                                <div data-bind="autoscroll: sortedMessages"></div>
+                            </div>
+							<div class="div-chat-room-users ">
+								<!-- ko foreach: sortedUsers -->
+								<div class="chat_user ellipsesoverflow" data-bind="event: { contextmenu: model.showRoomContextMenu.bind( $data, $parent, event) }, tooltip: displayInfo" data-container=".div-chat-room-window" data-placement="left">
+									<div class="status-visual" data-bind="css: { 'online': available, 'offline': offline, 'away': away, 'dnd': dnd }"></div>
+									<!-- ko if: user && user.hasLeagueImage() -->
+									<img width="24px" height="20px" data-bind="attr: {src: user.leagueImage()}"/>
+									<!-- /ko -->
+									<span class="selectable-text" data-bind="css: {'chat-room-user-name': !isModerator() && !isAdmin(),
+															'chat-room-moderator-name': isModerator() && !isAdmin(),
+															'chat-room-admin-name': isAdmin,
+															'chat-room-muted-name': isMuted,
+															'chat-room-blocked-name': blocked }, text: roomDisplayName"></span>
+								</div>
+								<!--/ko -->
+							</div>
+                        </div>
+                        <div class="div-chat-input">
+                            <form data-bind="submit: sendMessageLine">
+                                <input class="input-chat" type="text" data-bind="value: messageLine, valueUpdate: 'afterkeydown', event: {keydown: inputKeyDown}" autofocus />
+                            </form>
+                        </div>
+                        <!-- /ko -->
+                    </div>
+                </div>
+<!-- /ko -->

--- a/pachat/ui/mods/pachat/uberbar.css
+++ b/pachat/ui/mods/pachat/uberbar.css
@@ -1,3 +1,20 @@
+#roomContextMenu
+{
+  position: fixed;
+  z-index: 1000;
+  display: none;
+}
+
+#roomContextMenu ul.dropdown-menu
+{
+  display: block;
+}
+
+div.div-win.chat-room
+{
+  margin-bottom: -36px;
+}
+
 .markedline {
     background: #530505;
     border: 1px solid #080000;


### PR DESCRIPTION
- first commit for testing
- see ExtendedUserViewModel and RoomExtendedUserViewModel
- initial support for multiple logins with mapping between handle,
uberId and display name (see ChatRoomModel.displayNameHandleMap and
ChatRoomModel.fromJidMap)
- support for room users linked to PA users (will be tagged as CONTACT)
- PA users now have rank and league for future use
- real time messages are linked to room users via jid (see
ChatRoomModel.fromJidMap updated via presence)
- historical messages are linked to room users via jid even if offline
or go offline
- no pollution of roster map or user tag map with xmpp users (uber also
prevent now)
- cleanup of click binding works arounds with separate room context menu