### PR TITLE
Fix for chat history display names

### DIFF
--- a/pachat/ui/mods/pachat/jabber.js
+++ b/pachat/ui/mods/pachat/jabber.js
@@ -619,22 +619,34 @@ function Jabberer(uber_id, jabber_token, use_ubernetdev) {
             if (Strophe.getText(body[0]))
                 content = htmlSpecialChars(Strophe.getText(body[0]), true);
 
-            var delay = message.getElementsByTagName("delay");
-            var timestamp = new Date().getTime();
-            if (delay.length === 1) {
+// new properietary xmpp address extension with ofrom type based on http://xmpp.org/extensions/xep-0033.html
 
-                $delay = $(delay[0])
+            var address = message.getElementsByTagName("address");
+            if (address.length === 1)
+            {
 
-                jid = $delay.attr('from');
+                $address = $(address[0])
+
+                jid = $address.attr('jid');
 
                 uberId = JidToUberid(jid);
+
+            }
+            
+            var delay = message.getElementsByTagName("delay");
+            var timestamp = new Date().getTime();
+            if (delay.length === 1)
+            {
+
+                $delay = $(delay[0])
 
                 var dt = new Date($delay.attr("stamp")).getTime();
                 timestamp = dt;
 
                 // fix cases of "history from the future" due to the servertime of the xmpp server being rather questionable... 7 minutes ahead of reality
-
-                if (new Date().getTime() < timestamp) {
+                
+                if (new Date().getTime() < timestamp)
+                {
                     timestamp = new Date().getTime() - (1000 * 5);
                 }
             }

--- a/pachat/ui/mods/pachat/jabber.js
+++ b/pachat/ui/mods/pachat/jabber.js
@@ -619,7 +619,7 @@ function Jabberer(uber_id, jabber_token, use_ubernetdev) {
             if (Strophe.getText(body[0]))
                 content = htmlSpecialChars(Strophe.getText(body[0]), true);
 
-// new properietary xmpp address extension with ofrom type based on http://xmpp.org/extensions/xep-0033.html
+// new xmpp address extension with ofrom type based on http://xmpp.org/extensions/xep-0045.html#enter-history
 
             var address = message.getElementsByTagName("address");
             if (address.length === 1)


### PR DESCRIPTION
Looks like ejabberd has been updated with a new properietary xmpp
address extension using an ofrom type based on
http://xmpp.org/extensions/xep-0033.html

`  <message xmlns='jabber:client'
from='halcyon@conference.xmpp.uberent.com/mikeyh-PALOBBY'
to='15902732904735349906@xmpp.uberent.com/PALOBBY' type='groupchat'>
    <body>fixed on palobby</body>
    <addresses xmlns='http://jabber.org/protocol/address'>
      <address type='ofrom'
jid='15902732904735349906@xmpp.uberent.com/PALOBBY'/>
    </addresses>
    <delay xmlns='urn:xmpp:delay'
from='halcyon@conference.xmpp.uberent.com'
stamp='2015-04-07T02:30:42.082Z'/>
    <x xmlns='jabber:x:delay'
from='halcyon@conference.xmpp.uberent.com' stamp='20150407T02:30:42'/>
  </message>`